### PR TITLE
Fix msgext-multiparam-csharp issues

### DIFF
--- a/samples/msgext-multiparam-csharp/Bot/TeamsMessageExtension.cs
+++ b/samples/msgext-multiparam-csharp/Bot/TeamsMessageExtension.cs
@@ -46,7 +46,7 @@ namespace MsgExtMultiParamCSharp.Bot
 
             foreach (var stock in stockDataList)
             {
-                string resultCard = template.Expand(stockData);
+                string resultCard = template.Expand(stock);
 
                 var previewCard = new HeroCard
                 {

--- a/samples/msgext-multiparam-csharp/Bot/TeamsMessageExtension.cs
+++ b/samples/msgext-multiparam-csharp/Bot/TeamsMessageExtension.cs
@@ -36,10 +36,10 @@ namespace MsgExtMultiParamCSharp.Bot
 
             Debug.WriteLine($"🔍 StockIndex: '{stockIndex}' | NumberofStocks: '{numberOfStocks}' | P/B: '{pB}' | P/E: '{pE}'");
 
-            var stockData = File.ReadAllText("stock.data.json");
+            var stockData = File.ReadAllText(@"bot\stock.data.json");
             var stockDataList = JsonConvert.DeserializeObject<List<StockData>>(stockData);
 
-            var adaptiveCardJson = File.ReadAllText("stock.json");
+            var adaptiveCardJson = File.ReadAllText(@"bot\stock.json");
             var template = new AdaptiveCardTemplate(adaptiveCardJson);
 
             var attachments = new List<MessagingExtensionAttachment>();

--- a/samples/msgext-multiparam-csharp/Bot/TeamsMessageExtension.cs
+++ b/samples/msgext-multiparam-csharp/Bot/TeamsMessageExtension.cs
@@ -13,10 +13,10 @@ namespace MsgExtMultiParamCSharp.Bot
     {
         protected override Task<MessagingExtensionResponse> OnTeamsMessagingExtensionQueryAsync(ITurnContext<IInvokeActivity> turnContext, MessagingExtensionQuery query, CancellationToken cancellationToken)
         {
-            var stockIndex = query?.Parameters?[0]?.Value as string ?? string.Empty;
-            var numberOfStocks = query?.Parameters?[1]?.Value as string ?? string.Empty;
-            var pB = query?.Parameters?[2]?.Value as string ?? string.Empty;
-            var pE = query?.Parameters?[3]?.Value as string ?? string.Empty;
+            var stockIndex = GetQueryData(query, "stockIndex");
+            var numberOfStocks = GetQueryData(query, "NumberofStocks");
+            var pB = GetQueryData(query, "P/B");
+            var pE = GetQueryData(query, "P/E");
 
             // Basic: Find stocks in NASDAQ Stocks
             // [
@@ -73,6 +73,16 @@ namespace MsgExtMultiParamCSharp.Bot
                     Attachments = attachments,
                 },
             });
+        }
+        private string GetQueryData(MessagingExtensionQuery query, string key)
+        {
+            if (query?.Parameters?.Any() != true)
+                return string.Empty;
+
+            // Use LINQ to find the KeyValuePair with the specified key
+            var foundPair = query.Parameters.FirstOrDefault(pair => pair.Name == key);
+
+            return foundPair?.Value?.ToString() ?? string.Empty;
         }
     }
 }

--- a/samples/msgext-multiparam-csharp/appPackage/manifest.json
+++ b/samples/msgext-multiparam-csharp/appPackage/manifest.json
@@ -33,7 +33,7 @@
           "type": "query",
           "title": "General",
           "description": "Find number of stocks or listed equities using keywords, key ratios, index, and so on.",
-          "initialRun": true,
+          "initialRun": false,
           "fetchTask": false,
           "context": [ "commandBox", "compose", "message" ],
           "parameters": [

--- a/samples/msgext-multiparam-csharp/assets/sample.json
+++ b/samples/msgext-multiparam-csharp/assets/sample.json
@@ -10,7 +10,7 @@
       "This sample demonstrates how to use multiple parameters in a plugin for Microsoft Copilot for Microsoft 365 using .NET and Teams Toolkit for Visual Studio. It demonstrates how developers can use multi parameters in Microsoft Copilot for Microsoft 365 to support complex utterances and deep retrieval."
     ],
     "creationDateTime": "2023-11-15",
-    "updateDateTime": "2023-11-15",
+    "updateDateTime": "2023-11-17",
     "products": [
       "Microsoft Teams",
       "Microsoft 365 Copilot"


### PR DESCRIPTION
Merging this PR will close #34 

- Set `initialRun` to false
- Fix file paths
- Fix template expand
- Fix issue when param not passed

Co-authored-by: Wajeed-msft <31851992+Wajeed-msft@users.noreply.github.com>
