### PR TITLE
Set initialRun to false

### DIFF
--- a/samples/msgext-multiparam-js/appPackage/manifest.json
+++ b/samples/msgext-multiparam-js/appPackage/manifest.json
@@ -33,7 +33,7 @@
             "type": "query",
             "title": "General",
             "description": "Find number of stocks or listed equities using keywords, key ratios, index, and so on.",
-            "initialRun": true,
+            "initialRun": false,
             "fetchTask": false,
             "context": ["commandBox", "compose", "message"],
             "parameters": [

--- a/samples/msgext-multiparam-js/assets/sample.json
+++ b/samples/msgext-multiparam-js/assets/sample.json
@@ -10,7 +10,7 @@
       "This sample demonstrates how to use multiple parameters in a plugin for Microsoft Copilot for Microsoft 365 using JavaScript and Teams Toolkit for Visual Studio Code. It demonstrates how developers can use multi parameters in Microsoft Copilot for Microsoft 365 to support complex utterances and deep retrieval."
     ],
     "creationDateTime": "2023-11-15",
-    "updateDateTime": "2023-11-15",
+    "updateDateTime": "2023-11-17",
     "products": [
       "Microsoft Teams",
       "Microsoft 365 Copilot"

--- a/samples/msgext-multiparam-ts/appPackage/manifest.json
+++ b/samples/msgext-multiparam-ts/appPackage/manifest.json
@@ -33,7 +33,7 @@
           "type": "query",
           "title": "General",
           "description": "Find number of stocks or listed equities using keywords, key ratios, index, and so on.",
-          "initialRun": true,
+          "initialRun": false,
           "fetchTask": false,
           "context": ["commandBox", "compose", "message"],
           "parameters": [

--- a/samples/msgext-multiparam-ts/assets/sample.json
+++ b/samples/msgext-multiparam-ts/assets/sample.json
@@ -10,7 +10,7 @@
       "This sample demonstrates how to use multiple parameters in a plugin for Microsoft Copilot for Microsoft 365 using TypeScript and Teams Toolkit for Visual Studio Code. It demonstrates how developers can use multi parameters in Microsoft Copilot for Microsoft 365 to support complex utterances and deep retrieval."
     ],
     "creationDateTime": "2023-11-15",
-    "updateDateTime": "2023-11-15",
+    "updateDateTime": "2023-11-17",
     "products": [
       "Microsoft Teams",
       "Microsoft 365 Copilot"


### PR DESCRIPTION
Merging this PR will:

- Set `initialRun` to `false` on `msgext-multiparam-js` and `msgext-multiparam-ts` samples to resolve error when message extension is used in Microsoft Teams.
- Update sample metadata