### PR TITLE
fix: fix search options of js message extension sample

### DIFF
--- a/samples/msgext-doc-search-js/package-lock.json
+++ b/samples/msgext-doc-search-js/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@azure/search-documents": "^11.3.3",
+        "@azure/search-documents": "^12.0.0",
         "botbuilder": "^4.21.1",
         "restify": "^10.0.0"
       },
@@ -281,9 +281,9 @@
       }
     },
     "node_modules/@azure/search-documents": {
-      "version": "11.3.3",
-      "resolved": "https://registry.npmjs.org/@azure/search-documents/-/search-documents-11.3.3.tgz",
-      "integrity": "sha512-obltcTYsdiqDSIJVX/q58nodLsA4ctZaA5MHZoXxF1CxfmqVnshOJTipbjCVXAStSn0wQ68pf6p1ww9SM7s6mg==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@azure/search-documents/-/search-documents-12.0.0.tgz",
+      "integrity": "sha512-d9d53f2WWBpLHifk+LVn+AG52zuXvjgxJAdaH6kuT2qwrO1natcigtTgBM8qrI3iDYaDXsQhJSIMEgg9WKSoWA==",
       "dependencies": {
         "@azure/core-auth": "^1.3.0",
         "@azure/core-client": "^1.3.0",
@@ -296,7 +296,7 @@
         "tslib": "^2.2.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@azure/search-documents/node_modules/tslib": {

--- a/samples/msgext-doc-search-js/src/cogSearch.js
+++ b/samples/msgext-doc-search-js/src/cogSearch.js
@@ -20,17 +20,28 @@ async function doSemanticHybridSearch(query) {
   );
 
   const response = await searchClient.search(query, {
-    vector: {
-      value: await generateEmbeddings(query),
-      kNearestNeighborsCount: 3,
-      fields: ["contentVector"],
+    vectorSearchOptions: {
+      queries: [{
+        kind: "vector",
+        vector: await generateEmbeddings(query),
+        kNearestNeighborsCount: 3,
+        fields: ["contentVector"],
+      }],
     },
     select: ["title", "content", "url","filepath"],
     queryType: "simple",
     queryLanguage: "en-us",
-    semanticConfiguration: "my-semantic-config",
-    captions: "extractive",
-    answers: "extractive",
+    semanticSearchOptions: {
+      configurationName: "default",
+      /*
+      captions: {
+        captionType: "extractive",
+      },
+      answers: {
+        answerType: "extractive",
+      },
+      */
+    },
     top: 3,
   });
  


### PR DESCRIPTION
The msgext-doc-search-js sample uses `"@azure/search-documents": "^12.0.0"` in package.json and this PR fixes the search options parameter to use correct vector settings.

- Update to `vectorSearchOptions` and `semanticSearchOptions` per latest SDK reference.
- Comment out `captions` and `answers` to keep consistency with the .NET one (https://github.com/OfficeDev/Copilot-for-M365-Plugins-Samples/blob/main/samples/msgext-doc-search-csharp/Search/AISearch.cs#L51)