### PR TITLE
Work around refresh bug

### DIFF
--- a/samples/msgext-northwind-inventory-ts/src/searchApp.ts
+++ b/samples/msgext-northwind-inventory-ts/src/searchApp.ts
@@ -52,7 +52,12 @@ export class SearchApp extends TeamsActivityHandler {
             return actionHandler.handleTeamsCardActionCancelRestock(context);
           }
           default:
-            return CreateActionErrorResponse(400, 0, `ActionVerbNotSupported: ${context.activity.value.action.verb} is not a supported action verb.`);
+            // TODO: Handle Refresh correctly and set this line back to
+            // returning an error
+            // return CreateActionErrorResponse(400, 0, `ActionVerbNotSupported: ${context.activity.value.action.verb} is not a supported action verb.`);
+
+            // Workaround to stop choking on refresh activities
+            return CreateActionErrorResponse(200, 0, `ActionVerbNotSupported: ${context.activity.value.action.verb} is not a supported action verb.`);
          
         }
      


### PR DESCRIPTION
Code update to work around an issue - we are starting to receive Refresh activities and the code choked on them. This PR contains a workaround to effectively ignore these activities by returning an empty success response (no attachments).
We will implement proper Refresh handling in a later version but this will remove the errors we were seeing.